### PR TITLE
Disabling capturing of errors and warnings during R Check and unit te…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@ Changes
 
 1. Log file viewer uses chunking to allow viewing of huge log files.
 
+Bugfixes
+
+1. Disabling capturing of errors and warnings during R Check and unit testing so R Check fails if an error occurs during testing.
+
 
 ParallelLogger 2.0.1
 ====================
@@ -15,7 +19,7 @@ Changes
 
 2. Allow override of name of default loggers.
 
-BugFixes
+Bugfixes
 
 1. Correct function attribution in log when using rlang `warn` or `abort`.
 

--- a/R/Appenders.R
+++ b/R/Appenders.R
@@ -163,7 +163,7 @@ createEmailAppender <- function(layout = layoutEmail,
     }
     
     # Only main thread gets to send e-mails:
-    if (is.null(getOption("threadNumber"))) {
+    if (!is.null(getOption("threadNumber"))) {
       return()
     }
     

--- a/R/Layouts.R
+++ b/R/Layouts.R
@@ -201,9 +201,9 @@ layoutErrorReport <- function(level, message) {
 
 .tidyStackTrace <- function(trace) {
   if (is.null(getOption("threadNumber"))) {
-    trace <- trace[1:(length(trace) - 5)]
+    trace <- trace[1:(length(trace) - 3)]
   } else {
-    trace <- trace[23:(length(trace) - 5)]
+    trace <- trace[23:(length(trace) - 3)]
   }
   trace <- paste(1:length(trace), trace, sep = ": ")
   trace <- rev(trace)

--- a/R/Loggers.R
+++ b/R/Loggers.R
@@ -124,7 +124,7 @@ addDefaultFileLogger <- function(fileName, name = "DEFAULT_FILE_LOGGER") {
 #' addDefaultEmailLogger(mailSettings, "My R session", test = TRUE)
 #' logFatal("Something bad")
 #'
-#' unregisterLogger("DEFAULT")
+#' unregisterLogger("DEFAULT_EMAIL_LOGGER")
 #'
 #' @export
 addDefaultEmailLogger <- function(mailSettings,

--- a/R/Logging.R
+++ b/R/Logging.R
@@ -16,7 +16,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+isRmdCheck <- function() {
+  return(Sys.getenv("_R_CHECK_PACKAGE_NAME_", "") != "")
+}
+
+isUnitTest <- function() {
+  return(tolower(Sys.getenv("TESTTHAT", "")) == "true")
+}
+
 registerDefaultHandlers <- function() {
+  if (isRmdCheck() || isUnitTest()) {
+    message("Either in Rmd Check or a unit test (or both). Not capturing errors and warnings in ParallelLogger")
+    return(NULL)
+  }
   logBaseError <- function() {
     logFatal(gsub("\n", " ", geterrmessage()))
   }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,3 @@
 library(testthat)
+library(ParallelLogger)
 test_check("ParallelLogger")


### PR DESCRIPTION
…sting so R Check fails if an error occurs during testing.